### PR TITLE
Fix average to return 0 when expense list is empty

### DIFF
--- a/src/main/java/fintrek/ExpenseManager.java
+++ b/src/main/java/fintrek/ExpenseManager.java
@@ -35,8 +35,10 @@ public class ExpenseManager {
     public static double getAverageExpenses() {
         double totalExpenses = getTotalExpenses();
         int numExpenses = getLength();
-        double averageExpense = totalExpenses / numExpenses;
-        return averageExpense;
+        if(numExpenses == 0) {
+            return 0;
+        }
+        return totalExpenses / numExpenses;
     }
 
     public static void clearExpenses() {


### PR DESCRIPTION
Average will return 0 instead of NaN when expense list is empty
Closes #4 