### PR TITLE
Remove assertion for clearExpenses, fix bug with DELETE command

### DIFF
--- a/src/main/java/fintrek/ExpenseManager.java
+++ b/src/main/java/fintrek/ExpenseManager.java
@@ -46,8 +46,6 @@ public class ExpenseManager {
     }
 
     public static void clearExpenses() {
-        int numExpenses = getLength();
-        assert numExpenses > 0 : MessageDisplayer.EMPTY_LIST_MESSAGE;
         expenses.clear();
     }
 

--- a/src/main/java/fintrek/command/Command.java
+++ b/src/main/java/fintrek/command/Command.java
@@ -51,7 +51,7 @@ public enum Command {
             if (inValidRange) {
                 return new ExecutionResult(false, MessageDisplayer.INVALID_NUM_MESSAGE);
             }
-
+            ExpenseManager.popExpense(expenseIndex);
             int remainingExpenseIndex = ExpenseManager.getLength();
 
             String message = String.format(MessageDisplayer.DELETE_SUCCESS_MESSAGE_TEMPLATE,


### PR DESCRIPTION
Remove the assertion that the length of expense manager must be positive for clearExpenses,
fix bug with DELETE command by adding 

`ExpenseManager.popExpense(expenseIndex);`