### PR TITLE
Add /edit command and migrate to structured parsing for that command

### DIFF
--- a/src/main/java/fintrek/FinTrek.java
+++ b/src/main/java/fintrek/FinTrek.java
@@ -1,10 +1,11 @@
 package fintrek;
 
-import fintrek.expense.ExpenseManager;
+import fintrek.expense.core.RecurringExpenseManager;
+import fintrek.expense.core.RegularExpenseManager;
 import fintrek.misc.MessageDisplayer;
 import fintrek.parser.CommandRouter;
 import fintrek.parser.RouteResult;
-
+import fintrek.util.RecurringExpenseProcessor;
 import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,9 +23,8 @@ public class FinTrek {
         System.out.println(MessageDisplayer.CONVERSATION_STARTER);
 
         //automatically check recurring expenses at the start
-        if (ExpenseManager.checkRecurringExpenseSize() > 0) {
-            ExpenseManager.checkRecurringExpense();
-        }
+        RecurringExpenseProcessor.checkAndInsertDueExpenses(
+                RecurringExpenseManager.getInstance(), RegularExpenseManager.getInstance());
 
         Scanner reader = new Scanner(System.in);
         String userInput = reader.nextLine().trim(); // get user input

--- a/src/main/java/fintrek/command/Command.java
+++ b/src/main/java/fintrek/command/Command.java
@@ -1,10 +1,41 @@
 package fintrek.command;
 
+import fintrek.AppServices;
 import fintrek.command.registry.CommandInfo;
 import fintrek.command.registry.CommandResult;
+import fintrek.expense.service.ExpenseReporter;
+import fintrek.expense.service.ExpenseService;
+import fintrek.parser.CommandParser;
 
 public abstract class Command {
-    public abstract CommandResult execute(String arguments);
+    protected final ExpenseService service;
+    protected final ExpenseReporter reporter;
+
+    public Command(boolean isRecurring) {
+        if (isRecurring) {
+            this.service = AppServices.RECURRING_SERVICE;
+            this.reporter = AppServices.RECURRING_REPORTER;
+        } else {
+            this.service = AppServices.REGULAR_SERVICE;
+            this.reporter = AppServices.REGULAR_REPORTER;
+        }
+    }
+
+    public CommandResult execute(String arguments) {
+        throw new UnsupportedOperationException("This command requires a structured parser.");
+    }
+
+    public CommandResult executeStructured(Object parsedArgs) {
+        throw new UnsupportedOperationException("Structured execution not supported.");
+    }
+
+    public boolean supportsStructuredParsing() {
+        return false;
+    }
+
+    public CommandParser<?> getParser() {
+        return null;
+    }
 
     public String getDescription() {
         CommandInfo info = this.getClass().getAnnotation(CommandInfo.class);

--- a/src/main/java/fintrek/command/add/AddCommand.java
+++ b/src/main/java/fintrek/command/add/AddCommand.java
@@ -7,7 +7,7 @@ import fintrek.command.Command;
 import fintrek.command.registry.CommandInfo;
 import fintrek.command.registry.CommandResult;
 import fintrek.misc.MessageDisplayer;
-import fintrek.utils.InputValidator;
+import fintrek.util.InputValidator;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,6 +21,10 @@ import java.util.regex.Pattern;
 )
 
 public class AddCommand extends Command {
+
+    public AddCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
 
     @Override
     public CommandResult execute(String arguments) {

--- a/src/main/java/fintrek/command/add/AddRecurringCommand.java
+++ b/src/main/java/fintrek/command/add/AddRecurringCommand.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
+
 @CommandInfo(
         description = """
                 Format: /recurring [DESCRIPTION] $[AMOUNT] [DATE]
@@ -22,7 +23,12 @@ import java.time.format.DateTimeParseException;
                 will add 'mobile data' expense of $19.00 at every 29th date of each month
                 """
 )
+@Deprecated
 public class AddRecurringCommand extends Command {
+
+    public AddRecurringCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
 
     @Override
     public CommandResult execute(String arguments) {

--- a/src/main/java/fintrek/command/delete/DeleteCommand.java
+++ b/src/main/java/fintrek/command/delete/DeleteCommand.java
@@ -7,7 +7,7 @@ import fintrek.command.registry.CommandInfo;
 import fintrek.command.registry.CommandResult;
 import fintrek.misc.MessageDisplayer;
 
-import fintrek.utils.InputValidator;
+import fintrek.util.InputValidator;
 
 @CommandInfo(
         description = """
@@ -17,6 +17,10 @@ import fintrek.utils.InputValidator;
             """
 )
 public class DeleteCommand extends Command {
+
+    public DeleteCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
 
     @Override
     public CommandResult execute(String arguments) {

--- a/src/main/java/fintrek/command/delete/DeleteRecurringCommand.java
+++ b/src/main/java/fintrek/command/delete/DeleteRecurringCommand.java
@@ -7,7 +7,7 @@ import fintrek.command.registry.CommandResult;
 import fintrek.expense.core.Expense;
 import fintrek.expense.ExpenseManager;
 import fintrek.misc.MessageDisplayer;
-import fintrek.utils.InputValidator;
+import fintrek.util.InputValidator;
 
 @CommandInfo(
         description = """
@@ -16,7 +16,12 @@ import fintrek.utils.InputValidator;
             Example: /delete 2 - deletes the recurring expense with index number 2 on the list.
             """
 )
+@Deprecated
 public class DeleteRecurringCommand extends Command {
+
+    public DeleteRecurringCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
 
     @Override
     public CommandResult execute(String arguments) {

--- a/src/main/java/fintrek/command/edit/EditCommand.java
+++ b/src/main/java/fintrek/command/edit/EditCommand.java
@@ -46,7 +46,7 @@ public class EditCommand extends Command {
         }
 
         EditParseResult args = result.getResult();
-        int index = args.index();
+        int index = args.zeroBaseIndex();
 
         if (!isInValidIntRange(index, INDEX_LOWER_BOUND, service.countExpenses() - 1)) {
             return new CommandResult(false, MessageDisplayer.IDX_OUT_OF_BOUND_MESSAGE);

--- a/src/main/java/fintrek/command/edit/EditCommand.java
+++ b/src/main/java/fintrek/command/edit/EditCommand.java
@@ -18,6 +18,9 @@ import static fintrek.util.InputValidator.isInValidIntRange;
                 """
 )
 public class EditCommand extends Command {
+    private static final int INDEX_LOWER_BOUND = 0;
+    private static final String SUCCESS_MESSAGE_FORMAT = "Expense at index %d updated successfully:\n%s";
+
     private final EditArgumentParser parser = new EditArgumentParser();
 
     public EditCommand(boolean isRecurring) {
@@ -45,7 +48,7 @@ public class EditCommand extends Command {
         EditParseResult args = result.getResult();
         int index = args.index();
 
-        if (isInValidIntRange(index, 1, service.countExpenses())) {
+        if (!isInValidIntRange(index, INDEX_LOWER_BOUND, service.countExpenses() - 1)) {
             return new CommandResult(false, MessageDisplayer.IDX_OUT_OF_BOUND_MESSAGE);
         }
 
@@ -57,7 +60,7 @@ public class EditCommand extends Command {
 
         return new CommandResult(
                 true,
-                String.format("Expense at index %d updated successfully:\n%s", index + 1, updated)
+                String.format(SUCCESS_MESSAGE_FORMAT, index + 1, updated)
         );
     }
 

--- a/src/main/java/fintrek/command/edit/EditCommand.java
+++ b/src/main/java/fintrek/command/edit/EditCommand.java
@@ -1,0 +1,78 @@
+package fintrek.command.edit;
+
+import fintrek.command.Command;
+import fintrek.command.registry.CommandInfo;
+import fintrek.command.registry.CommandResult;
+import fintrek.expense.core.Expense;
+import fintrek.misc.MessageDisplayer;
+import fintrek.parser.CommandParser;
+import fintrek.parser.EditArgumentParser;
+import fintrek.parser.ParseResult;
+
+import static fintrek.util.InputValidator.isInValidIntRange;
+
+@CommandInfo(
+        description = """
+                Format: /edit [INDEX] [/d DESCRIPTION] [/$ AMOUNT] [/c CATEGORY]
+                Example: /edit 2 /d dinner /$ 25 /c Dining
+                """
+)
+public class EditCommand extends Command {
+    private final EditArgumentParser parser = new EditArgumentParser();
+
+    public EditCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
+
+    @Override
+    public boolean supportsStructuredParsing() {
+        return true;
+    }
+
+    @Override
+    public CommandParser<?> getParser() {
+        return parser;
+    }
+
+    @Override
+    public CommandResult execute(String arguments) {
+        ParseResult<EditParseResult> result = parser.parse(arguments);
+
+        if (!result.isSuccess()) {
+            return new CommandResult(false, result.getError());
+        }
+
+        EditParseResult args = result.getResult();
+        int index = args.index();
+
+        if (isInValidIntRange(index, 1, service.countExpenses())) {
+            return new CommandResult(false, MessageDisplayer.IDX_OUT_OF_BOUND_MESSAGE);
+        }
+
+        Expense original = service.getExpense(index);
+        Expense updated = buildUpdatedExpense(original, args.descriptor());
+
+        service.popExpense(index);
+        service.insertExpenseAt(index, updated);
+
+        return new CommandResult(
+                true,
+                String.format("Expense at index %d updated successfully:\n%s", index + 1, updated)
+        );
+    }
+
+    private Expense buildUpdatedExpense(Expense original, EditExpenseDescriptor descriptor) {
+        String description = descriptor.getDescription() != null
+                ? descriptor.getDescription() : original.getDescription();
+
+        double amount = descriptor.getAmount() != null
+                ? descriptor.getAmount() : original.getAmount();
+
+        String category = descriptor.getCategory() != null
+                ? descriptor.getCategory() : original.getCategory();
+
+        Expense updated = new Expense(description, amount, category);
+        updated.updateDate(original.getDate());
+        return updated;
+    }
+}

--- a/src/main/java/fintrek/command/edit/EditExpenseDescriptor.java
+++ b/src/main/java/fintrek/command/edit/EditExpenseDescriptor.java
@@ -1,0 +1,35 @@
+package fintrek.command.edit;
+
+public class EditExpenseDescriptor {
+    private String description;
+    private Double amount;
+    private String category;
+
+    public boolean hasAnyField() {
+        return description != null || amount != null || category != null;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description.trim();
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amountStr) {
+        this.amount = Double.parseDouble(amountStr);
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category.trim();
+    }
+}

--- a/src/main/java/fintrek/command/edit/EditParseResult.java
+++ b/src/main/java/fintrek/command/edit/EditParseResult.java
@@ -1,0 +1,4 @@
+package fintrek.command.edit;
+
+public record EditParseResult(int index, EditExpenseDescriptor descriptor) {
+}

--- a/src/main/java/fintrek/command/edit/EditParseResult.java
+++ b/src/main/java/fintrek/command/edit/EditParseResult.java
@@ -1,4 +1,4 @@
 package fintrek.command.edit;
 
-public record EditParseResult(int index, EditExpenseDescriptor descriptor) {
+public record EditParseResult(int zeroBaseIndex, EditExpenseDescriptor descriptor) {
 }

--- a/src/main/java/fintrek/command/help/HelpCommand.java
+++ b/src/main/java/fintrek/command/help/HelpCommand.java
@@ -15,6 +15,10 @@ import fintrek.misc.MessageDisplayer;
 )
 public class HelpCommand extends Command {
 
+    public HelpCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
+
     @Override
     public CommandResult execute(String arguments) {
         String message;

--- a/src/main/java/fintrek/command/list/ListCommand.java
+++ b/src/main/java/fintrek/command/list/ListCommand.java
@@ -16,6 +16,10 @@ import fintrek.misc.MessageDisplayer;
 )
 public class ListCommand extends Command {
 
+    public ListCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
+
     @Override
     public CommandResult execute(String arguments) {
         String message = String.format(MessageDisplayer.LIST_SUCCESS_MESSAGE_TEMPLATE,

--- a/src/main/java/fintrek/command/list/ListRecurringCommand.java
+++ b/src/main/java/fintrek/command/list/ListRecurringCommand.java
@@ -13,7 +13,12 @@ import fintrek.misc.MessageDisplayer;
             List all recorded recurring expenses.
             """
 )
+@Deprecated
 public class ListRecurringCommand extends Command {
+
+    public ListRecurringCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
 
     @Override
     public CommandResult execute(String arguments) {

--- a/src/main/java/fintrek/command/registry/CommandRegistrar.java
+++ b/src/main/java/fintrek/command/registry/CommandRegistrar.java
@@ -1,32 +1,43 @@
 package fintrek.command.registry;
-import fintrek.command.add.AddCommand;
-import fintrek.command.add.AddRecurringCommand;
-import fintrek.command.summary.AverageCommand;
+
 import fintrek.command.Command;
-import fintrek.command.delete.DeleteRecurringCommand;
+import fintrek.command.add.AddCommand;
+import fintrek.command.delete.DeleteCommand;
+import fintrek.command.edit.EditCommand;
 import fintrek.command.help.HelpCommand;
 import fintrek.command.list.ListCommand;
-import fintrek.command.list.ListRecurringCommand;
+import fintrek.command.summary.AverageCommand;
 import fintrek.command.summary.SummaryCommand;
 import fintrek.command.summary.TotalCommand;
-import fintrek.command.delete.DeleteCommand;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 public class CommandRegistrar {
     public static Map<String, Command> registerAll() {
         Map<String, Command> commands = new HashMap<>();
-        commands.put("add", new AddCommand());
-        commands.put("delete", new DeleteCommand());
-        commands.put("list", new ListCommand());
-        commands.put("total", new TotalCommand());
-        commands.put("average", new AverageCommand());
-        commands.put("help", new HelpCommand());
-        commands.put("recurring", new AddRecurringCommand());
-        commands.put("delete-recurring", new DeleteRecurringCommand());
-        commands.put("list-recurring", new ListRecurringCommand());
-        commands.put("summary", new SummaryCommand());
+
+        // Regular commands
+        commands.put("add", new AddCommand(false));
+        commands.put("delete", new DeleteCommand(false));
+        commands.put("edit", new EditCommand(false));
+        commands.put("list", new ListCommand(false));
+        commands.put("total", new TotalCommand(false));
+        commands.put("average", new AverageCommand(false));
+        commands.put("summary", new SummaryCommand(false));
+
+        // Recurring commands
+        commands.put("recurring", new AddCommand(true));
+        commands.put("delete-recurring", new DeleteCommand(true));
+        commands.put("edit-recurring", new EditCommand(true));
+        commands.put("list-recurring", new ListCommand(true));
+        commands.put("total-recurring", new TotalCommand(true));
+        commands.put("average-recurring", new AverageCommand(true));
+        commands.put("summary-recurring", new SummaryCommand(true));
+
+        // Misc
+        commands.put("help", new HelpCommand(false));
+
         return commands;
     }
 }

--- a/src/main/java/fintrek/command/summary/AverageCommand.java
+++ b/src/main/java/fintrek/command/summary/AverageCommand.java
@@ -17,6 +17,10 @@ import fintrek.misc.MessageDisplayer;
 )
 public class AverageCommand extends Command {
 
+    public AverageCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
+
     @Override
     public CommandResult execute(String arguments) {
         try {

--- a/src/main/java/fintrek/command/summary/SummaryCommand.java
+++ b/src/main/java/fintrek/command/summary/SummaryCommand.java
@@ -6,7 +6,7 @@ import fintrek.command.registry.CommandInfo;
 import fintrek.command.registry.CommandResult;
 import fintrek.expense.ExpenseManager;
 import fintrek.misc.MessageDisplayer;
-import fintrek.utils.InputValidator;
+import fintrek.util.InputValidator;
 
 @CommandInfo(
         description = """
@@ -16,6 +16,10 @@ import fintrek.utils.InputValidator;
             """
 )
 public class SummaryCommand extends Command {
+    public SummaryCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
+
     @Override
     public CommandResult execute(String arguments) {
         String message;

--- a/src/main/java/fintrek/command/summary/TotalCommand.java
+++ b/src/main/java/fintrek/command/summary/TotalCommand.java
@@ -17,6 +17,10 @@ import fintrek.misc.MessageDisplayer;
 )
 public class TotalCommand extends Command {
 
+    public TotalCommand(boolean isRecurring) {
+        super(isRecurring);
+    }
+
     @Override
     public CommandResult execute(String arguments) {
         try {

--- a/src/main/java/fintrek/expense/service/ExpenseService.java
+++ b/src/main/java/fintrek/expense/service/ExpenseService.java
@@ -22,6 +22,10 @@ public class ExpenseService {
         manager.add(expense);
     }
 
+    public void insertExpenseAt(int index, Expense expense) {
+        manager.insertAt(index, expense);
+    }
+
     public Expense getExpense(int index) {
         return manager.get(index);
     }

--- a/src/main/java/fintrek/parser/CommandParser.java
+++ b/src/main/java/fintrek/parser/CommandParser.java
@@ -1,5 +1,5 @@
 package fintrek.parser;
 
 public interface CommandParser<T> {
-    T parse(String input) throws IllegalArgumentException;
+    T parse(String input);
 }

--- a/src/main/java/fintrek/parser/CommandRouter.java
+++ b/src/main/java/fintrek/parser/CommandRouter.java
@@ -6,7 +6,7 @@ import fintrek.misc.MessageDisplayer;
 
 import java.util.logging.Logger;
 
-import static fintrek.utils.InputValidator.isNullOrBlank;
+import static fintrek.util.InputValidator.isNullOrBlank;
 
 public class CommandRouter {
     private static final Logger logger = Logger.getLogger(CommandRouter.class.getName());

--- a/src/main/java/fintrek/parser/EditArgumentParser.java
+++ b/src/main/java/fintrek/parser/EditArgumentParser.java
@@ -40,7 +40,7 @@ public class EditArgumentParser implements CommandParser<ParseResult<EditParseRe
             return ParseResult.failure(FORMAT_HINT);
         }
 
-        int index = Integer.parseInt(matcher.group(1)) - 1;
+        int zeroBaseIndex = Integer.parseInt(matcher.group(1)) - 1;
         EditExpenseDescriptor descriptor = extractDescriptor(matcher);
 
         if (descriptor == null) {
@@ -51,7 +51,7 @@ public class EditArgumentParser implements CommandParser<ParseResult<EditParseRe
             return ParseResult.failure(NO_FIELD_PROVIDED_MSG);
         }
 
-        return ParseResult.success(new EditParseResult(index, descriptor));
+        return ParseResult.success(new EditParseResult(zeroBaseIndex, descriptor));
     }
 
     private EditExpenseDescriptor extractDescriptor(Matcher matcher) {

--- a/src/main/java/fintrek/parser/EditArgumentParser.java
+++ b/src/main/java/fintrek/parser/EditArgumentParser.java
@@ -1,0 +1,81 @@
+package fintrek.parser;
+
+import fintrek.command.edit.EditExpenseDescriptor;
+import fintrek.command.edit.EditParseResult;
+import fintrek.misc.MessageDisplayer;
+import fintrek.util.InputValidator;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses user input for the /edit command into a structured EditParseResult.
+ */
+public class EditArgumentParser implements CommandParser<ParseResult<EditParseResult>> {
+
+    private static final String INDEX_PATTERN = "(\\d+)";
+    private static final String DESC_PATTERN = "(?:\\s+/d\\s+([^/$]+))?";
+    private static final String AMOUNT_PATTERN = "(?:\\s+/\\$\\s+(\\S+))?";
+    private static final String CATEGORY_PATTERN = "(?:\\s+/c\\s+(\\S+))?";
+
+    private static final Pattern EDIT_PATTERN = Pattern.compile(
+            "^" + INDEX_PATTERN + DESC_PATTERN + AMOUNT_PATTERN + CATEGORY_PATTERN + "$"
+    );
+
+    private static final String FORMAT_HINT =
+            "Invalid format. Usage: /edit [INDEX] [/d DESC] [/$ AMOUNT] [/c CATEGORY]";
+    private static final String NO_FIELD_PROVIDED_MSG =
+            "Please provide at least one field to edit using /d, /$ or /c.";
+
+    @Override
+    public ParseResult<EditParseResult> parse(String input) {
+        if (InputValidator.isNullOrBlank(input)) {
+            return ParseResult.failure(
+                    String.format(MessageDisplayer.ARG_EMPTY_MESSAGE_TEMPLATE, "edit")
+            );
+        }
+
+        Matcher matcher = EDIT_PATTERN.matcher(input.trim());
+        if (!matcher.matches()) {
+            return ParseResult.failure(FORMAT_HINT);
+        }
+
+        int index = Integer.parseInt(matcher.group(1)) - 1;
+        EditExpenseDescriptor descriptor = extractDescriptor(matcher);
+
+        if (descriptor == null) {
+            return ParseResult.failure(MessageDisplayer.INVALID_AMT_MESSAGE);
+        }
+
+        if (!descriptor.hasAnyField()) {
+            return ParseResult.failure(NO_FIELD_PROVIDED_MSG);
+        }
+
+        return ParseResult.success(new EditParseResult(index, descriptor));
+    }
+
+    private EditExpenseDescriptor extractDescriptor(Matcher matcher) {
+        EditExpenseDescriptor descriptor = new EditExpenseDescriptor();
+
+        String description = matcher.group(2);
+        String amountStr = matcher.group(3);
+        String category = matcher.group(4);
+
+        if (description != null) {
+            descriptor.setDescription(description);
+        }
+
+        if (amountStr != null) {
+            if (!InputValidator.isValidAmountInput(amountStr)) {
+                return null; // triggers a failure in the caller
+            }
+            descriptor.setAmount(amountStr);
+        }
+
+        if (category != null) {
+            descriptor.setCategory(category);
+        }
+
+        return descriptor;
+    }
+}

--- a/src/main/java/fintrek/parser/ParseResult.java
+++ b/src/main/java/fintrek/parser/ParseResult.java
@@ -1,0 +1,36 @@
+package fintrek.parser;
+
+/**
+ * Generic result wrapper for parse operations.
+ */
+public class ParseResult<T> {
+    private final boolean success;
+    private final T result;
+    private final String error;
+
+    private ParseResult(boolean success, T result, String error) {
+        this.success = success;
+        this.result = result;
+        this.error = error;
+    }
+
+    public static <T> ParseResult<T> success(T result) {
+        return new ParseResult<>(true, result, null);
+    }
+
+    public static <T> ParseResult<T> failure(String errorMessage) {
+        return new ParseResult<>(false, null, errorMessage);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public T getResult() {
+        return result;
+    }
+
+    public String getError() {
+        return error;
+    }
+}

--- a/src/main/java/fintrek/util/InputValidator.java
+++ b/src/main/java/fintrek/util/InputValidator.java
@@ -1,4 +1,4 @@
-package fintrek.utils;
+package fintrek.util;
 
 public class InputValidator {
 

--- a/src/main/java/fintrek/util/RecurringExpenseProcessor.java
+++ b/src/main/java/fintrek/util/RecurringExpenseProcessor.java
@@ -1,4 +1,4 @@
-package fintrek.utils;
+package fintrek.util;
 
 import fintrek.expense.core.Expense;
 import fintrek.expense.core.ExpenseOperation;

--- a/src/test/java/fintrek/command/add/AddCommandTest.java
+++ b/src/test/java/fintrek/command/add/AddCommandTest.java
@@ -22,7 +22,7 @@ public class AddCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"$1 /c transport", "", "$2.5", "$", "bus $", "bus $ /c transport", "bus $1 /c", "   "})
     public void testAddCommandInvalidFormat(String input) {
-        AddCommand addCommand = new AddCommand();
+        AddCommand addCommand = new AddCommand(false);
         CommandResult result = addCommand.execute(input);
 
         TestUtils.assertCommandFailure(result, input);
@@ -32,7 +32,7 @@ public class AddCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"invalid", "1.2.3", "-1", "2."})
     public void testAddCommandInvalidAmount(String inputAmount) {
-        AddCommand addCommand = new AddCommand();
+        AddCommand addCommand = new AddCommand(false);
         String input = "bus $" + inputAmount + "/c transport";
         CommandResult result = addCommand.execute(input);
 
@@ -43,7 +43,7 @@ public class AddCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"20", "0.99", "45.67", "1.0"})
     public void testAddCommandValidAmount(String inputAmount) {
-        AddCommand addCommand = new AddCommand();
+        AddCommand addCommand = new AddCommand(false);
         int initialSize = ExpenseManager.getLength();
         String input = "bus $" + inputAmount + " /c transport";
         CommandResult result = addCommand.execute(input);
@@ -58,7 +58,7 @@ public class AddCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"bus $1", "bus$1", "bus $ 1"})
     public void testAddCommandTwoValidInputs(String input) {
-        AddCommand addCommand = new AddCommand();
+        AddCommand addCommand = new AddCommand(false);
         int initialSize = ExpenseManager.getLength();
         CommandResult result = addCommand.execute(input);
 
@@ -72,7 +72,7 @@ public class AddCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"bus $1 /c transport", "bus $ 1 /c transport"})
     public void testAddCommandThreeValidInputs(String input) {
-        AddCommand addCommand = new AddCommand();
+        AddCommand addCommand = new AddCommand(false);
         int initialSize = ExpenseManager.getLength();
         CommandResult result = addCommand.execute(input);
 

--- a/src/test/java/fintrek/command/delete/DeleteCommandTest.java
+++ b/src/test/java/fintrek/command/delete/DeleteCommandTest.java
@@ -23,7 +23,7 @@ public class DeleteCommandTest {
 
     @Test
     public void testDeleteCommandEmptyIndex() {
-        DeleteCommand deleteCommand = new DeleteCommand();
+        DeleteCommand deleteCommand = new DeleteCommand(false);
         CommandResult result = deleteCommand.execute("");
 
         TestUtils.assertCommandFailure(result, "");
@@ -33,7 +33,7 @@ public class DeleteCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"invalid", "0.99", "2.", "1.2.3", "-1", "0"})
     public void testDeleteCommandInvalidIndex(String input) {
-        DeleteCommand deleteCommand = new DeleteCommand();
+        DeleteCommand deleteCommand = new DeleteCommand(false);
         CommandResult result = deleteCommand.execute(input);
 
         TestUtils.assertCommandFailure(result, input);
@@ -43,7 +43,7 @@ public class DeleteCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"999"}) // Assuming ExpenseManager has <999 items
     public void testDeleteCommandOutOfBounds(String input) {
-        DeleteCommand deleteCommand = new DeleteCommand();
+        DeleteCommand deleteCommand = new DeleteCommand(false);
         CommandResult result = deleteCommand.execute(input);
 
         TestUtils.assertCommandFailure(result, input);
@@ -52,7 +52,7 @@ public class DeleteCommandTest {
 
     @Test
     public void testDeleteCommandValidInput() {
-        DeleteCommand deleteCommand = new DeleteCommand();
+        DeleteCommand deleteCommand = new DeleteCommand(false);
         int expectedSize = ExpenseManager.getLength() - 1;
         Expense removedExpense = ExpenseManager.getExpense(0);
         String expenseStr = '"' + removedExpense.toString() + '"';

--- a/src/test/java/fintrek/command/help/HelpCommandTest.java
+++ b/src/test/java/fintrek/command/help/HelpCommandTest.java
@@ -25,7 +25,7 @@ public class HelpCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"", " "})
     public void testHelpCommand_general_success(String input) {
-        HelpCommand helpCommand = new HelpCommand();
+        HelpCommand helpCommand = new HelpCommand(false);
         CommandResult result = helpCommand.execute(input);
         String expectedMessage = CommandRegistry.getAllCommandDescriptions();
 
@@ -42,7 +42,7 @@ public class HelpCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"add", "ADD", " add ", "adddd", "/add"})
     public void testHelpCommand_add_success(String input) {
-        HelpCommand helpCommand = new HelpCommand();
+        HelpCommand helpCommand = new HelpCommand(false);
         CommandResult result = helpCommand.execute(input);
         String expectedMessage = CommandRegistry.getCommand("add").getDescription();
 
@@ -59,7 +59,7 @@ public class HelpCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"delete", "DELETE", " delete ", "deleteee", "/delete"})
     public void testHelpCommand_delete_success(String input) {
-        HelpCommand helpCommand = new HelpCommand();
+        HelpCommand helpCommand = new HelpCommand(false);
         CommandResult result = helpCommand.execute(input);
         String expectedMessage = CommandRegistry.getCommand("delete").getDescription();
 
@@ -76,7 +76,7 @@ public class HelpCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"total", "TOTAL", " total ", "totalll", "/total"})
     public void testHelpCommand_total_success(String input) {
-        HelpCommand helpCommand = new HelpCommand();
+        HelpCommand helpCommand = new HelpCommand(false);
         CommandResult result = helpCommand.execute(input);
         String expectedMessage = CommandRegistry.getCommand("total").getDescription();
 
@@ -93,7 +93,7 @@ public class HelpCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"average", "AVERAGE", " average ", "averageee", "/average"})
     public void testHelpCommand_average_success(String input) {
-        HelpCommand helpCommand = new HelpCommand();
+        HelpCommand helpCommand = new HelpCommand(false);
         CommandResult result = helpCommand.execute(input);
         String expectedMessage = CommandRegistry.getCommand("average").getDescription();
 
@@ -110,7 +110,7 @@ public class HelpCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"summary", "SUMMARY", " summary ", "summaryyy", "/summary"})
     public void testHelpCommand_summary_success(String input) {
-        HelpCommand helpCommand = new HelpCommand();
+        HelpCommand helpCommand = new HelpCommand(false);
         CommandResult result = helpCommand.execute(input);
         String expectedMessage = CommandRegistry.getCommand("summary").getDescription();
 
@@ -127,7 +127,7 @@ public class HelpCommandTest {
     @ParameterizedTest
     @ValueSource(strings = {"hello", "delet", "help"})
     public void testHelpCommand_unknownTopic_returnsError(String input) {
-        HelpCommand helpCommand = new HelpCommand();
+        HelpCommand helpCommand = new HelpCommand(false);
         CommandResult result = helpCommand.execute(input);
 
         assertFalse(result.isSuccess(), MessageDisplayer.ASSERT_COMMAND_FAILURE_PREFIX + "'" + input + "'");
@@ -141,7 +141,7 @@ public class HelpCommandTest {
      */
     @Test
     public void testHelpCommand_getDescription_success() {
-        HelpCommand command = new HelpCommand();
+        HelpCommand command = new HelpCommand(false);
         String expectedDescription = """
             Format: /help [COMMAND]
             Displays help message for all commands. Optionally pass a keyword to show usage for a specific command.

--- a/src/test/java/fintrek/command/list/ListCommandTest.java
+++ b/src/test/java/fintrek/command/list/ListCommandTest.java
@@ -26,7 +26,7 @@ public class ListCommandTest {
      */
     @Test
     public void testListCommand_emptyList_success() {
-        ListCommand command = new ListCommand();
+        ListCommand command = new ListCommand(false);
         CommandResult result = command.execute("");
         String expectedMessage = String.format(MessageDisplayer.LIST_SUCCESS_MESSAGE_TEMPLATE,
                 ExpenseManager.listAllExpenses());
@@ -45,7 +45,7 @@ public class ListCommandTest {
     public void testListCommand_filledList_success() {
         TestUtils.addConstantExpenses();
 
-        ListCommand command = new ListCommand();
+        ListCommand command = new ListCommand(false);
         CommandResult result = command.execute("");
         String expectedMessage = String.format(MessageDisplayer.LIST_SUCCESS_MESSAGE_TEMPLATE,
                 ExpenseManager.listAllExpenses());
@@ -62,7 +62,7 @@ public class ListCommandTest {
      */
     @Test
     public void testListCommand_getDescription_success() {
-        ListCommand command = new ListCommand();
+        ListCommand command = new ListCommand(false);
         String expectedDescription = """
             Format: /list
             Lists all recorded expenses.

--- a/src/test/java/fintrek/command/summary/AverageCommandTest.java
+++ b/src/test/java/fintrek/command/summary/AverageCommandTest.java
@@ -19,7 +19,7 @@ public class AverageCommandTest {
 
     @Test
     public void testAverageCommandEmptyList() {
-        AverageCommand averageCommand = new AverageCommand();
+        AverageCommand averageCommand = new AverageCommand(false);
         CommandResult result = averageCommand.execute("");
         String expectedMessage = String.format(MessageDisplayer.AVERAGE_SUCCESS_MESSAGE_TEMPLATE, 0.0);
 
@@ -30,7 +30,7 @@ public class AverageCommandTest {
     @Test
     public void testAverageCommandFilledList() {
         TestUtils.addConstantExpenses();
-        AverageCommand averageCommand = new AverageCommand();
+        AverageCommand averageCommand = new AverageCommand(false);
         CommandResult result = averageCommand.execute("");
         double expectedAverage = ExpenseManager.getAverageExpenses();
         String expectedMessage = String.format(MessageDisplayer.AVERAGE_SUCCESS_MESSAGE_TEMPLATE, expectedAverage);

--- a/src/test/java/fintrek/command/summary/TotalCommandTest.java
+++ b/src/test/java/fintrek/command/summary/TotalCommandTest.java
@@ -30,7 +30,7 @@ public class TotalCommandTest {
      */
     @Test
     public void testTotalCommand_emptyList_success() {
-        TotalCommand totalCommand = new TotalCommand();
+        TotalCommand totalCommand = new TotalCommand(false);
         CommandResult result = totalCommand.execute("");
         String expectedMessage = String.format(MessageDisplayer.TOTAL_SUCCESS_MESSAGE_TEMPLATE, 0.0);
 
@@ -49,7 +49,7 @@ public class TotalCommandTest {
     public void testTotalCommand_filledList_success() {
         TestUtils.addConstantExpenses();
 
-        TotalCommand totalCommand = new TotalCommand();
+        TotalCommand totalCommand = new TotalCommand(false);
         CommandResult result = totalCommand.execute("");
         double expectedTotal = ExpenseManager.getTotalExpenses();
         String expectedMessage = String.format(MessageDisplayer.TOTAL_SUCCESS_MESSAGE_TEMPLATE, expectedTotal);
@@ -66,7 +66,7 @@ public class TotalCommandTest {
      */
     @Test
     public void testTotalCommand_getDescription_success() {
-        TotalCommand command = new TotalCommand();
+        TotalCommand command = new TotalCommand(false);
         String expectedDescription = """
             Format: /total
             Returns sum of all expenses in the list, but will return 0 if the list is empty.

--- a/src/test/java/fintrek/util/TestCommandUtils.java
+++ b/src/test/java/fintrek/util/TestCommandUtils.java
@@ -8,7 +8,8 @@ public class TestCommandUtils {
     public static class FakeCommand extends Command {
         private final String name;
 
-        public FakeCommand(String name) {
+        public FakeCommand(String name, boolean isRecurring) {
+            super(isRecurring);
             this.name = name;
         }
 
@@ -20,7 +21,7 @@ public class TestCommandUtils {
 
     public static void registerFakeCommands(String... commandNames) {
         for (String name : commandNames) {
-            TestCommandRegistry.register(name, new FakeCommand(name));
+            TestCommandRegistry.register(name, new FakeCommand(name, false));
         }
     }
 


### PR DESCRIPTION
- Added structured parser support in base Command class
- Updated EditCommand to use EditArgumentParser and executeStructured logic
- Introduced EditExpenseDescriptor and EditParseResult to encapsulate parsed fields
- Deprecated legacy unstructured parsing via Command#execute(String) for structured commands 
**Note: Currently, the add, delete, and list recurring commands are not added to the command registry. It needs to be updated accordingly.