### PR TITLE
add glossary and fix unit test in addcommand

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -360,7 +360,11 @@ command or the User Guide.
 
 ## Glossary
 
-* *glossary item* - Definition
+* *Regular Expense* - An expense that has been done, usually on the day of addition of expense.
+* *Recurring Expense* - An expense that is repeated monthly and will be automatically added into the regular expense list on the stipulated date.
+* *Manager* - A class that elps to specify which list to target, Regular Expense or Recurring Expense list
+* *ExpenseService* - A class that manages simple `ArrayList` functions such as `add()` and `remove()`.
+* *ExpenseReporter* - A class that manages more complicated functions such as `getTotalByCategory()` and `getHighestCategory()`.
 
 ## Instructions for manual testing
 

--- a/src/test/java/fintrek/command/add/AddCommandTest.java
+++ b/src/test/java/fintrek/command/add/AddCommandTest.java
@@ -153,7 +153,7 @@ public class AddCommandTest {
     }
 
     /**
-     * Tests the description of the add command.
+     * Tests to get description of the add command.
      * Ensures the command returns the correct description.
      */
     @ParameterizedTest

--- a/src/test/java/fintrek/command/add/AddCommandTest.java
+++ b/src/test/java/fintrek/command/add/AddCommandTest.java
@@ -175,13 +175,13 @@ public class AddCommandTest {
                              adds a regular expense with description 'concert tickets' with the amount $35.80,
                              category 'LEISURE' and date '03-05-2025'.""";
         }
-        String expectedDescription = formatString + "\n" +
+        String expectedDescription = formatString.trim() + "\n" +
                 """
                 AMOUNT must be a positive number greater than 0.
                 CATEGORY is an optional argument.
                 DATE is an optional argument which must be in the form dd-MM-yyyy.
                 """
-                + exampleString;
+                + exampleString.trim();
 
         assertEquals(expectedDescription, addCommand.getDescription(),
                 MessageDisplayer.ASSERT_COMMAND_EXPECTED_OUTPUT + MessageDisplayer.ASSERT_GET_DESC);

--- a/src/test/java/fintrek/command/add/AddCommandTest.java
+++ b/src/test/java/fintrek/command/add/AddCommandTest.java
@@ -165,13 +165,13 @@ public class AddCommandTest {
         if (isRecurring) {
             formatString = "Format: /add-recurring <DESCRIPTION> $<AMOUNT> [/c <CATEGORY>] [/dt <DATE>]";
             exampleString = """
-                    Example: /add-recurring concert tickets $35.80 /c LEISURE /d 03-05-2025 -
+                    Example: /add-recurring concert tickets $35.80 /c LEISURE /dt 03-05-2025 -
                              adds a recurring expense with description 'concert tickets' with the amount $35.80,
                              category 'LEISURE' and date '03-05-2025'.""";
         } else {
             formatString = "Format: /add <DESCRIPTION> $<AMOUNT> [/c <CATEGORY>] [/dt <DATE>]";
             exampleString = """
-                    Example: /add concert tickets $35.80 /c LEISURE /d 03-05-2025 -
+                    Example: /add concert tickets $35.80 /c LEISURE /dt 03-05-2025 -
                              adds a regular expense with description 'concert tickets' with the amount $35.80,
                              category 'LEISURE' and date '03-05-2025'.""";
         }


### PR DESCRIPTION
1. edit the glossary section
2. edit addCommand test cases to show the right expected getDescription() tests