### PR TITLE
Update UG and add a max limit on the average command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -11,13 +11,15 @@
 2. Download the latest release v2.1 `tp.jar`.
 3. Copy the file into your desired folder on your computer. This folder will be set as the _home folder_ for FinTrek.
 4. Open a command terminal, `cd` into the folder you put the
-`.jar` file in, and use the `java -jar tp.jar` command to run the application.
+`.jar` file in, and use the `java -jar tp.jar` command to run the application. You will see something similar to
+what is shown below.
+   ![img.png](images/img.png)
+
 5. Input some commands to start
 managing your expenses or type `/help` to learn about the commands.
 Alternatively, refer to the [Features](#Features) section for the full list of
 commands and its details.
 
-![img.png](images/img.png)
 
 > #### ❗CAUTION
 > - Only enter a command after you see the leading input arrow `>`. Commands will only be read in after `>`.
@@ -160,6 +162,9 @@ Displays all recorded expenses.
 /list
 ```
 
+If extraneous parameters are supplied to `/list`, e.g. `/list everything please`, then
+`/list` would simply behave as usual and display all recorded expenses.
+
 ---
 ### 🗃️ Sorting Expenses: `/list-sort` 
 
@@ -203,19 +208,27 @@ Shows the total amount spent.
 /total
 ```
 Note that if the total amount is greater than `10,000,000,000` (ten billion),
-then an error message will be returned.
+then an error message will be returned. 
+
+Also note that if extraneous parameters are supplied to `/total`, e.g. `/total cs2113`, then
+`/total` would simply behave as usual and return the total amount spent.
 
 ---
 ### 📊 Calculating Average Expense: `/average` 
 
 #### General Expense
 
-Displays the average amount spent per recorded expense.
+Displays the average amount spent per recorded expense. Note that `/average` would
+fail to work and will return an error message if the `total` amount of expenses in the list
+exceeds `10_000_000_000` (ten billion).
 
 **Format**:
 ```
 /average
 ```
+
+If extraneous parameters are supplied to `/average`, e.g. `/average hello!`, then
+`/average` would simply behave as usual and return the average amount spent.
 
 ---
 ### 🛠️ Adding Custom Categories: `/add-category`

--- a/docs/team/edwardrl101.md
+++ b/docs/team/edwardrl101.md
@@ -6,34 +6,56 @@ analyze, and manage their expenses using short commands.
 It is designed for speed, simplicity, and ease of use.
 
 ### Summary of Contributions
-* Code contributed: 
-https://nus-cs2113-ay2425s2.github.io/tp-dashboard/?search=&sort=groupTitle&sortWithin=title&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=true&checkedFileTypes=docs~functional-code~test-code~other&since=2025-02-21&tabOpen=true&tabType=authorship&tabAuthor=edwardrl101&tabRepo=AY2425S2-CS2113-F12-1%2Ftp%5Bmaster%5D&authorshipIsMergeGroup=false&authorshipFileTypes=docs~functional-code~test-code~other&authorshipIsBinaryFileTypeChecked=false&authorshipIsIgnoredFilesChecked=false
+* Code contributed:
+  ([RepoSense Link](https://nus-cs2113-ay2425s2.github.io/tp-dashboard/?search=&sort=groupTitle&sortWithin=title&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=true&checkedFileTypes=docs~functional-code~test-code~other&since=2025-02-21&tabOpen=true&tabType=authorship&tabAuthor=edwardrl101&tabRepo=AY2425S2-CS2113-F12-1%2Ftp%5Bmaster%5D&authorshipIsMergeGroup=false&authorshipFileTypes=docs~functional-code~test-code~other&authorshipIsBinaryFileTypeChecked=false&authorshipIsIgnoredFilesChecked=false))
+
 
 * Enhancements implemented:
   * Added the functionality to calculate average expenses in FinTrek
   * Enabled saving and loading of monthly budgets, regular expenses, and recurring expenses in FinTrek.
-  * Enabled the addition of expenses with dates.
-  * Code refactoring for readability and adapting the coding standard whenever necessary
+  * Implemented a file data parser to read file data from the save file and load user data accordingly.
+  * Enabled the addition of expenses with dates, and  added max amount limits for `/budget` and `/average` commands.
+  * Refactored code to maintain coding standards, readability, and obey the SRP.
   * Wrote JUnit tests to ensure methods are tested with high coverage.
+  * Extensively added JavaDoc comments to non-trivial methods.
+  * Added the feature to set monthly budgets, and receive budget warnings
+when the monthly budget is exceeded or almost exceeded.
+ 
+
 
 * Contributions to the UG:
-  * Added important notes about the command format
+  * Added important notes about the command format and a quick start guide.
   * Added and updated descriptions for the `/summary`, `/add`, `bye`, and `/budget` commands
   * Updated the command summary to include the latest list of commands
   as well as their format
-  * Listed out important information regarding the saving and loading
-  of data for FinTrek
+  * Listed out important cautionary information  regarding the saving and loading
+  of data for FinTrek, and what not to do with the save file.
+  * Added examples to almost all of the features.
+  * Answered the FAQ section.
+
 
 * Contributions to the DG:
   * Added and updated user stories 
+  * Wrote out the step-by-step execution flows for the `/add`, `/list`, `/average`, and `/help` commands.
+  * Drew out UML sequence diagrams for the `/average` and `/help` commands.
+  * Drew out UML class diagram for the Command Parser component and briefly explained
+its implementation.
+  * Added Non-Functional Requirements (NFRs) to the DG
+
+
 
 * Contributions to team-based tasks:
     * Updated the gradle.yml to validate gradle wrapper which fixed the issue with the CI failing (PR [#39](https://github.com/AY2425S2-CS2113-F12-1/tp/pull/39))
     * Code enhancements and refactoring whenever necessary
+
+
 * Review contributions:
-    * Made 28 comments on others' PRs as of now (https://nus-cs2113-ay2425s2.github.io/dashboards/contents/tp-comments.html)
-    * Reviewed PRs (some examples: PR [#24](https://github.com/AY2425S2-CS2113-F12-1/tp/pull/24#discussion_r1997640278),
+    * Made 28 comments on others' PRs as of March 31 ([CS2113 tP Comments Dashboard](https://nus-cs2113-ay2425s2.github.io/dashboards/contents/tp-comments.html)) and likely
+  to have made about 40 by now.
+    * Reviewed PRs (PR [#24](https://github.com/AY2425S2-CS2113-F12-1/tp/pull/24#discussion_r1997640278),
   PR [#19](https://github.com/AY2425S2-CS2113-F12-1/tp/pull/19#discussion_r1995777073),
   PR [#31](https://github.com/AY2425S2-CS2113-F12-1/tp/pull/31#discussion_r1997669041))
+
+
 * Contributions beyond the project team:
-    * Went the extra mile to deliver beyond the minimum review comments (19 comments) for others' iP, assessing them objectively (https://nus-cs2113-ay2425s2.github.io/dashboards/contents/ip-comments.html)
+    * Went the extra mile to deliver beyond the minimum review comments (19 comments) for others' iP, assessing them objectively ([CS2113 iP Comments Dashboard](https://nus-cs2113-ay2425s2.github.io/dashboards/contents/ip-comments.html))

--- a/src/main/java/fintrek/command/summary/AverageCommand.java
+++ b/src/main/java/fintrek/command/summary/AverageCommand.java
@@ -17,6 +17,7 @@ import fintrek.misc.MessageDisplayer;
         regularExample = "/average returns (TransportExpense1 + TransportExpense2 + FoodExpense1) / 3."
 )
 public class AverageCommand extends Command {
+    private static final double MAX_EXCEEDED = -1;
     private final boolean isRecurringExpense;
     public AverageCommand(boolean isRecurring) {
         super(isRecurring);
@@ -33,6 +34,11 @@ public class AverageCommand extends Command {
     public CommandResult execute(String arguments) {
         try {
             double average = reporter.getAverage();
+            if(average == MAX_EXCEEDED) {
+                String errorMessage = MessageDisplayer.ERROR_CALCULATING_AVERAGE_EXPENSES +
+                        MessageDisplayer.TOTAL_EXCEEDS_LIMIT_MSG;
+                return new CommandResult(false, errorMessage);
+            }
             String message = (isRecurringExpense) ?
                     String.format(MessageDisplayer.AVERAGE_RECURRING_SUCCESS_MESSAGE_TEMPLATE, average):
                     String.format(MessageDisplayer.AVERAGE_SUCCESS_MESSAGE_TEMPLATE, average);

--- a/src/main/java/fintrek/command/summary/TotalCommand.java
+++ b/src/main/java/fintrek/command/summary/TotalCommand.java
@@ -17,6 +17,7 @@ import fintrek.misc.MessageDisplayer;
         regularExample = "/total returns (TransportExpense1 + TransportExpense2 + FoodExpense1)."
 )
 public class TotalCommand extends Command {
+    public static final double MAX_EXCEEDED = -1.0;
     public TotalCommand(boolean isRecurring) {
         super(isRecurring);
     }
@@ -30,7 +31,7 @@ public class TotalCommand extends Command {
     @Override
     public CommandResult execute(String arguments) {
         double total = reporter.getTotal();
-        if (total == -1) {
+        if (total == MAX_EXCEEDED) {
             String errorMessage = MessageDisplayer.ERROR_CALCULATING_TOTAL_EXPENSES +
                     MessageDisplayer.TOTAL_EXCEEDS_LIMIT_MSG;
             return new CommandResult(false, errorMessage);

--- a/src/main/java/fintrek/expense/service/ExpenseReporter.java
+++ b/src/main/java/fintrek/expense/service/ExpenseReporter.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
  * Some examples include total, average and get highest
  */
 public class ExpenseReporter {
+    public static final double MAX_EXCEEDED = -1.0;
     private final ExpenseOperation manager;
 
     public ExpenseReporter(ExpenseOperation manager) {
@@ -30,7 +31,7 @@ public class ExpenseReporter {
                 .mapToDouble(Expense::getAmount)
                 .sum();
         if (total > MessageDisplayer.MAX_AMOUNT) {
-            return -1;
+            return MAX_EXCEEDED;
         }
         return total;
     }
@@ -52,7 +53,10 @@ public class ExpenseReporter {
 
     public double getAverage() {
         int count = manager.getLength();
-        return count == 0 ? 0 : getTotal() / count;
+        if(getTotal() == MAX_EXCEEDED) {
+            return MAX_EXCEEDED;
+        }
+        return (count == 0) ? 0 : getTotal() / count;
     }
 
     //@@author szeyingg - helper method for building an expense list string

--- a/src/main/java/fintrek/misc/MessageDisplayer.java
+++ b/src/main/java/fintrek/misc/MessageDisplayer.java
@@ -51,6 +51,7 @@ public class MessageDisplayer {
     public static final String ERROR_CALCULATING_TOTAL_EXPENSES = "Error calculating total expenses: ";
     public static final String BUDGET_EXCEEDS_LIMIT_MSG = "Budget exceeds $1 billion. Please input a lower amount.";
     public static final String TOTAL_EXCEEDS_LIMIT_MSG = "Total expenses exceed $10 billion.";
+    public static final String AVERAGE_EXCEEDS_LIMIT_MSG = "Average expenses exceed $1 billion.";
     public static final String ERROR_CALCULATING_AVERAGE_EXPENSES = "Error calculating average expenses: ";
     public static final String NO_COMMAND_MESSAGE =
             "Please enter a command starting with '/'. Type '/help' for more information.";

--- a/src/test/java/fintrek/command/summary/AverageCommandTest.java
+++ b/src/test/java/fintrek/command/summary/AverageCommandTest.java
@@ -127,4 +127,24 @@ public class AverageCommandTest {
         assertEquals(expectedDescription, averageCommand.getDescription(),
                 MessageDisplayer.ASSERT_COMMAND_EXPECTED_OUTPUT + MessageDisplayer.ASSERT_GET_DESC);
     }
+
+    /**
+     * Verifies that attempting to calculate the average amount spent out of
+     * a list of expenses whose total amount exceeds $10 billion returns an error message.
+     * @param isRecurring a boolean value indicating if the expense is recurring.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAverageCommand_expensiveFilledList_returnsError(boolean isRecurring) {
+        TestUtils.addHugeConstantExpenses();
+        TestUtils.addHugeConstantRecurringExpenses();
+        AverageCommand command = new AverageCommand(isRecurring);
+        CommandResult result = command.execute("");
+
+        TestUtils.assertCommandMessage(result, MessageDisplayer.ASSERT_FILLED_LIST,
+                MessageDisplayer.ERROR_CALCULATING_AVERAGE_EXPENSES +
+                        MessageDisplayer.TOTAL_EXCEEDS_LIMIT_MSG);
+        TestUtils.assertCommandFailure(result, MessageDisplayer.ASSERT_FILLED_LIST);
+
+    }
 }


### PR DESCRIPTION
- Give clarification on commands that accept extraneous parameters (e.g. /list, /total, /average) in the UG
- Add a max limit on the average command
- Extract constants to avoid magic literals
- Add JUnit test for attempting to calculate the average of a list with total amount higher than the max limit